### PR TITLE
payloads now have a fingerprint which can be used to de-dupe

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ var Mustache = require('mustache')
 
 function AnnotationPoller (opts) {
   this.pollInterval = opts.pollInterval || 3000
-  this.endpoint = '/api/v1/annotations.js'
+  this.endpoint = '/api/v1/annotations'
   this.annotations = {}
-  this.template = '<li id="annotation-{{id}}" style="{{status}}"><span>{{description}}</span><a href="{{{external-link}}}">{{external-link-text}}</a></li>'
+  this.template = '<li id="annotation-{{id}}" style="{{status}}" data-fingerprint={{fingerprint}}><span>{{description}}</span><a href="{{{external-link}}}">{{external-link-text}}</a></li>'
   this.addonSelector = '#npm-addon-box'
 }
 
@@ -58,7 +58,10 @@ AnnotationPoller.prototype.renderAnnotations = function () {
     annotationElement = $('#annotation-' + annotation.id)
     newAnnotationElement = Mustache.render(_this.template, annotation)
     if (annotationElement.length) {
-      annotationElement.replaceWith(newAnnotationElement)
+      // don't render the element unless its fingerprint has changed.
+      if (annotationElement.data('fingerprint') !== annotation.fingerprint) {
+        annotationElement.replaceWith(newAnnotationElement)
+      }
     } else {
       addonBox.append(newAnnotationElement)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "annotation-poller",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "poll for annotations from external services, place them on packages",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@
 require('jsdom-global')()
 
 var annotationPoller = require('./')
-var endpoint = '/api/v1/annotations.js'
+var endpoint = '/api/v1/annotations'
 var $ = require('jquery')
 
 require('jquery-mockjax')($)
@@ -12,9 +12,10 @@ $.mockjaxSettings.logging = false
 require('chai').should()
 
 describe('annotation-poller', function () {
-  beforeEach(function () {
+  beforeEach(function (cb) {
     document.body.innerHTML = '<ul class="box" id="npm-addon-box"></ul>'
     $.mockjax.clear()
+    return cb()
   })
 
   it('grabs an initial list of annotations when the page loads', function (done) {
@@ -27,7 +28,7 @@ describe('annotation-poller', function () {
         description: 'foo security integration',
         'external-link': 'http://example.com/foo-package/audit',
         'external-link-text': 'start audit',
-        timeout: 20
+        fingerprint: 'foo'
       }]
     })
 
@@ -50,7 +51,7 @@ describe('annotation-poller', function () {
         description: 'my awesome integration',
         'external-link': 'http://example.com/foo-package/audit',
         'external-link-text': 'start audit',
-        timeout: 20
+        fingerprint: 'bar'
       }]
     })
 
@@ -73,7 +74,7 @@ describe('annotation-poller', function () {
         description: 'my awesome integration',
         'external-link': 'http://example.com/foo-package/audit',
         'external-link-text': 'start audit',
-        timeout: 20
+        fingerprint: 'foo'
       }]
     })
 
@@ -89,7 +90,7 @@ describe('annotation-poller', function () {
           description: 'my awesome integration',
           'external-link': 'http://example.com/foo-package/audit',
           'external-link-text': 'view details',
-          timeout: 20
+          fingerprint: 'bar'
         }]
       })
 
@@ -112,7 +113,7 @@ describe('annotation-poller', function () {
         description: 'my awesome integration',
         'external-link': 'http://example.com/foo-package/audit',
         'external-link-text': 'start audit',
-        timeout: 20
+        fingerprint: 'foo'
       }]
     })
 
@@ -128,7 +129,7 @@ describe('annotation-poller', function () {
           description: 'my second integration',
           'external-link': 'http://example.com/foo-package/audit',
           'external-link-text': 'view details',
-          timeout: 20
+          fingerprint: 'foo'
         }]
       })
 


### PR DESCRIPTION
annotation payloads are returned with a fingerprint, elements should only be replaced in the DOM if the fingerprint has changed.

This prevents weirdness that can be caused when you're trying to interact with an element, and we swap it out with a new identical element.
