### PR TITLE
feat: we should be polling for annotations specific to a package

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@ var Mustache = require('mustache')
 
 function AnnotationPoller (opts) {
   this.pollInterval = opts.pollInterval || 3000
-  this.endpoint = '/api/v1/annotations'
+  this.pkg = opts.pkg // what package should we load annotations for?
+  this.endpoint = '/api/v1/annotations/' + this.pkg
   this.annotations = {}
   this.template = '<li id="annotation-{{id}}" style="{{status}}" data-fingerprint={{fingerprint}}><span>{{description}}</span><a href="{{{external-link}}}">{{external-link-text}}</a></li>'
   this.addonSelector = '#npm-addon-box'

--- a/test.js
+++ b/test.js
@@ -3,7 +3,8 @@
 require('jsdom-global')()
 
 var annotationPoller = require('./')
-var endpoint = '/api/v1/annotations'
+var pkg = encodeURIComponent('cool module')
+var endpoint = '/api/v1/annotations/' + pkg
 var $ = require('jquery')
 
 require('jquery-mockjax')($)
@@ -32,7 +33,7 @@ describe('annotation-poller', function () {
       }]
     })
 
-    var poller = annotationPoller({pollInterval: 50})
+    var poller = annotationPoller({pollInterval: 50, pkg: pkg})
     poller.start(function () {
       poller.annotations['abc-123-abc'].status = 'warn'
       poller.annotations['abc-123-abc'].description = 'foo security integration'
@@ -55,7 +56,7 @@ describe('annotation-poller', function () {
       }]
     })
 
-    var poller = annotationPoller({pollInterval: 50})
+    var poller = annotationPoller({pollInterval: 50, pkg: pkg})
     poller.start(function () {
       $('ul li').length.should.equal(1)
       $('ul li').text().should.match(/my awesome integration/)
@@ -78,7 +79,7 @@ describe('annotation-poller', function () {
       }]
     })
 
-    var poller = annotationPoller({pollInterval: 50})
+    var poller = annotationPoller({pollInterval: 50, pkg: pkg})
     poller.start(function () {
       $.mockjax.clear()
       $.mockjax({
@@ -117,7 +118,7 @@ describe('annotation-poller', function () {
       }]
     })
 
-    var poller = annotationPoller({pollInterval: 50})
+    var poller = annotationPoller({pollInterval: 50, pkg: pkg})
     poller.start(function () {
       $.mockjax.clear()
       $.mockjax({


### PR DESCRIPTION
we need to be polling for annotations specific to the package that is currently loaded.
