### PR TITLE
fix: immediately poll when we load, don't stop polling on failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,23 +34,23 @@ AnnotationPoller.prototype._installExtensions = function () {
 
 AnnotationPoller.prototype.start = function (loaded) {
   var _this = this
-  var updating = false
+  var poll = function () {
+    _this.getAnnotations(function () {
+      _this.renderAnnotations()
+      if (loaded) {
+        loaded()
+        loaded = null
+      }
+    })
+  }
 
   $(document).ready(function () {
     this.interval = setInterval(function () {
-      if (updating) return
-      updating = true
-
-      _this.getAnnotations(function () {
-        updating = false
-        _this.renderAnnotations()
-        if (loaded) {
-          loaded()
-          loaded = null
-        }
-      })
+      poll()
     }, _this.pollInterval)
   })
+
+  poll()
 }
 
 AnnotationPoller.prototype.stop = function () {

--- a/index.js
+++ b/index.js
@@ -34,8 +34,12 @@ AnnotationPoller.prototype._installExtensions = function () {
 
 AnnotationPoller.prototype.start = function (loaded) {
   var _this = this
+  var updating = false
   var poll = function () {
+    if (updating) return
+    updating = true
     _this.getAnnotations(function () {
+      updating = false
       _this.renderAnnotations()
       if (loaded) {
         loaded()
@@ -63,6 +67,7 @@ AnnotationPoller.prototype.getAnnotations = function (cb) {
     $.each(data, function (i, annotation) {
       _this.annotations[annotation.id] = annotation
     })
+  }).always(function () {
     return cb()
   })
 }

--- a/test.js
+++ b/test.js
@@ -74,6 +74,20 @@ describe('annotation-poller', function () {
     })
   })
 
+  it('gracefully handles an upstream error', function (done) {
+    $.mockjax({
+      url: endpoint,
+      status: 500,
+      responseText: "ENOGOOD"
+    })
+
+    var poller = annotationPoller({pollInterval: 50, pkg: pkg})
+    poller.start(function () {
+      poller.stop()
+      return done()
+    })
+  })
+
   it('respects the element ordering', function (done) {
     $.mockjax({
       url: endpoint,


### PR DESCRIPTION
1. makes the integration feel more snappy.
2. addresses an issue our integration partners were running into (an upstream failure would cause the integration to break).
